### PR TITLE
For the love of God (:)) - faster rotations as default

### DIFF
--- a/src/stores/timer_store.js
+++ b/src/stores/timer_store.js
@@ -94,7 +94,7 @@ var Store = Reflux.createStore({
 
   loadMinutes() {
     var minutes = Storage.getItem('minutes');
-    return minutes != null ? minutes : 30;
+    return minutes != null ? minutes : 5;
   },
 
   commitMinutes() {


### PR DESCRIPTION
Hi, 

came across this simple tool and it looked useful. And was useful. We used it for a workshop. Thanks a lot. 

A very simple change; please set the default time to something shorter. I suggest 5 minutes rotation or the navigators will totally lose interest and you drop the flow in the team. 

Thanks